### PR TITLE
debounce: Параметр invokeAsap не должен отключать отложенный вызов

### DIFF
--- a/src/jquery.debounce/jquery.debounce.js
+++ b/src/jquery.debounce/jquery.debounce.js
@@ -27,18 +27,26 @@ $.extend({
         }
 
         var timer;
+        var lastInvokeTime = 0;
+
+        function invoke(time, args) {
+            if (time - lastInvokeTime > timeout) {
+                fn.apply(this, args);
+                lastInvokeTime = time;
+            }
+        }
 
         return function() {
 
-            var args = arguments;
+            var time = new Date().valueOf();
             ctx = ctx || this;
 
-            invokeAsap && !timer && fn.apply(ctx, args);
+            invokeAsap && !timer && invoke.call(ctx, time, arguments);
 
             clearTimeout(timer);
 
             timer = setTimeout(function() {
-                invokeAsap || fn.apply(ctx, args);
+                invoke.call(ctx, time, arguments);
                 timer = null;
             }, timeout);
 

--- a/src/jquery.debounce/jquery.debounce.min.js
+++ b/src/jquery.debounce/jquery.debounce.min.js
@@ -6,4 +6,4 @@
  * http://www.opensource.org/licenses/mit-license.php
  * http://www.gnu.org/licenses/gpl.html
  *
- */(function(a){a.extend({debounce:function(a,b,c,d){arguments.length==3&&typeof c!="boolean"&&(d=c,c=!1);var e;return function(){var f=arguments;d=d||this,c&&!e&&a.apply(d,f),clearTimeout(e),e=setTimeout(function(){c||a.apply(d,f),e=null},b)}},throttle:function(a,b,c){var d,e,f;return function(){e=arguments,f=!0,c=c||this,d||function(){f?(a.apply(c,e),f=!1,d=setTimeout(arguments.callee,b)):d=null}()}}})})(jQuery);
+ */(function(e){e.extend({debounce:function(n,l,t,u){if(arguments.length==3&&typeof t!="boolean"){u=t;t=false}var i;var f=0;function o(e,t){if(e-f>l){n.apply(this,t);f=e}}return function(){var e=(new Date).valueOf();u=u||this;if(t&&!i){o.call(u,e,arguments)}clearTimeout(i);i=setTimeout(function(){o.call(u,e,arguments);i=null},l)}},throttle:function(e,t,n){var l,u,i;return function(){u=arguments;i=true;n=n||this;l||function(){if(i){e.apply(n,u);i=false;l=setTimeout(arguments.callee,t)}else{l=null}}()}}})})(jQuery);


### PR DESCRIPTION
В статье https://habr.com/ru/post/60957/ сказано про debounce:
1. ...
2. Реальный вызов происходит сразу, а все остальные попытки вызова игнорируются, пока не пройдет время, большее или равное задержке, отсчитанной от времени последней попытки.

Но сейчас реализация не соответствует этому описанию, потому что при использовании второго варианта происходит только первый мгновенный вызов, а последний после окончания задержки не выполняется.